### PR TITLE
Added auto fill name to Pilot Sign

### DIFF
--- a/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
+++ b/src/main/java/net/countercraft/movecraft/listener/BlockListener.java
@@ -246,6 +246,13 @@ public class BlockListener implements Listener {
 //				event.setCancelled(true);
 			}
         }
+        
+        if(signText.equalsIgnoreCase( "Pilot:")) {
+            String crewName=org.bukkit.ChatColor.stripColor(event.getLine(1));
+        	if(p.getName().isEmpty) {
+				event.setLine(1, p.getName());
+		}
+        }
     }
 	
 	@EventHandler(priority = EventPriority.LOW)


### PR DESCRIPTION
If a player places a blank pilot sign, move craft will now fill it with his username, like the crew sign!